### PR TITLE
Removed unused variables

### DIFF
--- a/mm/page_alloc.c
+++ b/mm/page_alloc.c
@@ -3629,8 +3629,6 @@ should_compact_retry(struct alloc_context *ac, int order, int alloc_flags,
 	int max_retries = MAX_COMPACT_RETRIES;
 	int min_priority;
 	bool ret = false;
-	int retries = *compaction_retries;
-	enum compact_priority priority = *compact_priority;
 
 	if (!order)
 		return false;


### PR DESCRIPTION
Fixing warning: unused variable 'priority' [-Wunused-variable]